### PR TITLE
Adding routes to config and result

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,13 +3,16 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/containernetworking/cni/pkg/types"
 )
 
 // IPAMConfig is used to load the options specified in the configuration file
 type IPAMConfig struct {
-	Type             string `json:"type"`
-	LogToFile        string `json:"logToFile"`
-	SubnetPrefixSize string `json:"subnetPrefixSize"`
+	Type             string        `json:"type"`
+	LogToFile        string        `json:"logToFile"`
+	SubnetPrefixSize string        `json:"subnetPrefixSize"`
+	Routes           []types.Route `json:"routes"`
 }
 
 // Net loads the options of the CNI network configuration file

--- a/main.go
+++ b/main.go
@@ -64,6 +64,10 @@ func cmdAdd(args *skel.CmdArgs) error {
 		},
 	}
 
+	r.IP4.Routes = append(
+		ipamConf.Routes,
+	)
+
 	log.Infof("rancher-cni-ipam: %s", fmt.Sprintf("r: %#v", r))
 	return r.Print()
 }


### PR DESCRIPTION
**Why this is needed:**
While using VXLAN CNI driver, there is a vtep interface created with an IP in the subnet of 169.254.0.0/16. Due to this, the route for the metadata IP (169.254.169.250) becomes this vtep interface. Hence rancher-metadata is not reachable in case of VXLAN.

**What this change does:**
With this change we are adding an option to add a route in the IPAM config which gets returned to the CNI driver and the routes are programmed when the interface is being configured.