### PR TITLE
add IPAMConfig gateway

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@ type IPAMConfig struct {
 	IsDebugLevel         string        `json:"isDebugLevel"`
 	SubnetPrefixSize     string        `json:"subnetPrefixSize"`
 	Routes               []types.Route `json:"routes"`
+	Gateway              string        `json:"gateway"`
 	RancherContainerUUID types.UnmarshallableString
 }
 

--- a/main.go
+++ b/main.go
@@ -66,7 +66,8 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 	r := &types.Result{
 		IP4: &types.IPConfig{
-			IP: net.IPNet{IP: ip, Mask: ipnet.Mask},
+			IP:      net.IPNet{IP: ip, Mask: ipnet.Mask},
+			Gateway: net.ParseIP(ipamConf.Gateway),
 		},
 	}
 


### PR DESCRIPTION
Sometimes rancher-cni-bridge might use IP4.Gateway.
```
	if n.IsGW {
		if n.UseBridgeIPAsGW {
			result.IP4.Gateway = bridgeIP
		} else if result.IP4.Gateway == nil {
			result.IP4.Gateway = calcGatewayIP(&result.IP4.IP)
		}
	}
```

So I think we shoud add gateway field in IPAMConfig. I need use it in Rancher Flat networking.