### PR TITLE
Fixing config to properly parse CIDR notation

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,8 +3,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-
 	"github.com/containernetworking/cni/pkg/types"
+	"strings"
 )
 
 // IPAMConfig is used to load the options specified in the configuration file
@@ -20,8 +20,9 @@ type IPAMConfig struct {
 
 // Net loads the options of the CNI network configuration file
 type Net struct {
-	Name string      `json:"name"`
-	IPAM *IPAMConfig `json:"ipam"`
+	Name         string      `json:"name"`
+	BridgeSubnet string      `json:"bridgeSubnet"`
+	IPAM         *IPAMConfig `json:"ipam"`
 }
 
 // LoadIPAMConfig loads the IPAM configuration from the given bytes
@@ -37,6 +38,14 @@ func LoadIPAMConfig(bytes []byte, args string) (*IPAMConfig, error) {
 
 	if err := types.LoadArgs(args, n.IPAM); err != nil {
 		return nil, fmt.Errorf("failed to parse args %s: %v", args, err)
+	}
+
+	//If BridgeSubnet is a valid CIDR block set the PrefixSize
+	i := strings.Split(n.BridgeSubnet, "/")
+	if len(i) > 1 {
+		n.IPAM.SubnetPrefixSize = "/" + i[1]
+	} else {
+		n.IPAM.SubnetPrefixSize = ""
 	}
 
 	return n.IPAM, nil


### PR DESCRIPTION
This is a fix in reference to rancher/rancher#8938

Documentation / Examples show putting in an IP address in CIDR notation, but the config was ignoring it.

This preserves current behavior but will now properly parse and pass the CIDR prefix.